### PR TITLE
Add libcnefeatureconfig.so into prebuilt blobs list due to ics_strawberry

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -134,6 +134,7 @@ copy_local_files()
 COMMON_LIBS="
 	libauth.so
 	libcm.so
+	libcnefeatureconfig.so
 	libdiag.so
 	libdivxdrmdecrypt.so
 	libdsi_netctrl.so


### PR DESCRIPTION
The file as below needs libcnefeatureconfig.so in compile time. (in ics_strawberry_rb5.1 revision)
    framework/base/core/jni/android_hardware_fm.cpp
