### PR TITLE
Bug905784 - Create symlink to default system.prop during build

### DIFF
--- a/full_hamachi.mk
+++ b/full_hamachi.mk
@@ -1,4 +1,7 @@
 $(call inherit-product, device/qcom/common/common.mk)
+
+$(shell ln -sf $(abspath $(TOP))/device/qcom/msm7627a/system.prop $(LOCAL_PATH)/system.prop)
+
 PRODUCT_COPY_FILES := \
   device/qcom/hamachi/touch.idc:system/usr/idc/msg2133.idc \
   device/qcom/hamachi/touch.idc:system/usr/idc/ft5x06_ts.idc \


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=905784
