### PR TITLE
Bug905784 - add symlink to system.prop

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -1,0 +1,1 @@
+../msm7627a/system.prop


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=905784
